### PR TITLE
Mention terminal mode in remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Technically Vim comes with a whopping 12 modes, 6 of them can be mapped:
 | `:cmap`   | `:cnoremap`   | command-line                     |
 | `:omap`   | `:onoremap`   | operator-pending                 |
 | `:imap`   | `:inoremap`   | insert                           |
+| `:tmap`   | `:tnoremap`   | terminal                         |
 
 E.g. this defines the mapping for normal mode only:
 


### PR DESCRIPTION
I'm going to be really controversial, and propose a neovim change into this document.

I know it's not quite as popular yet, but I think that it's worth supporting, and talking about it's extended features.