### PR TITLE
Fix smaple command line

### DIFF
--- a/content/neovim.md
+++ b/content/neovim.md
@@ -50,7 +50,7 @@ If you want to share your vimrc with Neovim, you can easily do that like this
 ```sh
 $ cd
 $ mkdir -p .config
-$ ln -s .vim .config/nvim
+$ ln -s ../.vim .config/nvim
 $ cd .vim
 $ ln -s vimrc init.vim
 ```


### PR DESCRIPTION
The source path of "ln -s" is relative to the target.