### PR TITLE
use md syntax for vimrc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ for yourself. :-)
 So here it is: [minimal-vimrc](contents/minimal-vimrc.vim)
 
 In case you're interested, here's
-[my vimrc][https://github.com/mhinz/dotfiles/blob/master/.vim/vimrc].
+[my vimrc](https://github.com/mhinz/dotfiles/blob/master/.vim/vimrc).
 
 **TIP**: Most plugin authors maintain several plugins and also publish their
 vimrc on Github (often in a repository called "vim-config" or "dotfiles"), so


### PR DESCRIPTION
I believe this was the intention so just wanted to give a fix. thanks for the repo btw