### PR TITLE
Add reference to themer in colorscheme section.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -61,6 +61,8 @@ Here's a list of commonly used colorschemes:
 - [yowish](https://github.com/kabbamine/yowish.vim)
 - [zenburn](https://github.com/jnurmine/Zenburn)
 
+Alternatively, generate your own personal colorscheme using [themer](https://github.com/mjswensen/themer).
+
 ## By topic
 
 #### Alignment


### PR DESCRIPTION
[themer](https://github.com/mjswensen/themer) is a command-line tool that takes a set of user-defined colors and generates matching themes for editors (including Vim), terminals, other apps, and wallpaper. (It also has a [GUI](https://github.com/mjswensen/themer-gui) wrapper.) I thought that some Vimmers may be interesting in being able to easily create their own custom color schemes without necessarily writing one by hand from scratch. [More about themer.](https://themer.mjswensen.com)