### PR TITLE
Mention Colortemplate as a colorscheme generator.

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -63,7 +63,8 @@ Here's a list of commonly used colorschemes:
 - [yowish](https://github.com/kabbamine/yowish.vim)
 - [zenburn](https://github.com/jnurmine/Zenburn)
 
-Alternatively, generate your own colorscheme using [themer](https://github.com/mjswensen/themer).
+Alternatively, generate your own colorscheme using [themer](https://github.com/mjswensen/themer)
+or [Colortemplate](https://github.com/lifepillar/vim-colortemplate).
 
 ## By topic
 


### PR DESCRIPTION
Colortemplate is a Vim colorscheme generator based on a simple, but full-featured, syntax, written by myself.