### PR TITLE
Removed missing cheatsheet link since url not longer available

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,6 @@ Help:
 
 - http://people.csail.mit.edu/vgod/vim/vim-cheat-sheet-en.png
 - https://cdn.shopify.com/s/files/1/0165/4168/files/preview.png
-- http://www.nathael.org/Data/vi-vim-cheat-sheet.svg
 - http://michael.peopleofhonoronly.com/vim/vim_cheat_sheet_for_programmers_screen.png
 - http://www.rosipov.com/images/posts/vim-movement-commands-cheatsheet.png
 


### PR DESCRIPTION
It came to my attention that link is not available (as whole website where it was located). Looked through the guide, it was used just once so I deleted it.
#130 