### PR TITLE
Updated the referred link for temp files

### DIFF
--- a/static/minimal-vimrc.vim
+++ b/static/minimal-vimrc.vim
@@ -51,7 +51,7 @@ if &shell =~# 'fish$'
 endif
 
 " Put all temporary files under the same directory.
-" https://github.com/mhinz/vim-galore#handling-backup-swap-undo-and-viminfo-files
+" https://github.com/mhinz/vim-galore#temporary-files
 set backup
 set backupdir   =$HOME/.vim/files/backup/
 set backupext   =-vimbackup


### PR DESCRIPTION
The link in the comment at [line 54](https://github.com/mhinz/vim-galore/blob/master/static/minimal-vimrc.vim#L54) was broken. 

Fixed it by pointing to https://github.com/mhinz/vim-galore#temporary-files