### PR TITLE
Translated Project to Spanish, add 'Spanish' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <div>
     <a href='https://github.com/wsdjeg/vim-galore-zh_cn'>Chinese</a> |
     <a href='http://postd.cc/?s=vim-galore'>Japanese</a> |
+    <a href='https://github.com/AsleyR/vim-galore'>Spanish</a> |
     <a href='https://github.com/lsrdg/vim-galore'>Portuguese</a> |
     <a href='http://givi.olnd.ru/vim-galore/vim-galore-ru.html'>Russian</a> |
     <a href='https://github.com/kyoz/vim-galore-vi'>Vietnamese</a>


### PR DESCRIPTION
Hey @mhinz, I translated the whole project to Spanish (you can see how it end up in: https://github.com/AsleyR/vim-galore), so I added a 'Spanish' <a></a> link in the header of the project that links back to the Spanish version of the project I translated.

Btw, thank you for creating this project, it has been really helpful to me in learning how to use Vim 😁.