### PR TITLE
Update minimal-vimrc.vim

### DIFF
--- a/static/minimal-vimrc.vim
+++ b/static/minimal-vimrc.vim
@@ -52,11 +52,13 @@ endif
 
 " Put all temporary files under the same directory.
 " https://github.com/mhinz/vim-galore#temporary-files
+" To ensure that the following configurations work correctly, please execute the following command.
+" mkdir -p ~/.vim/files/{backup,swap,undo,info} && touch ~/.vim/files/info/viminfo
 set backup
 set backupdir   =$HOME/.vim/files/backup/
 set backupext   =-vimbackup
 set backupskip  =
-set directory   =$HOME/.vim/files/swap//
+set directory   =$HOME/.vim/files/swap/
 set updatecount =100
 set undofile
 set undodir     =$HOME/.vim/files/undo/


### PR DESCRIPTION
- The forward slash (/) is not necessary at the end of the directory path ~/.vim/files. It will work with or without the slash, but it's more common to omit it.
- We can add a command in the comment to ensure that the directories and files are created.